### PR TITLE
Feature timer is armed method

### DIFF
--- a/include/sst.h
+++ b/include/sst.h
@@ -124,6 +124,9 @@ void SST_TimeEvt_arm(
 bool SST_TimeEvt_disarm(
     SST_TimeEvt * const me);
 
+bool SST_TimeEvt_isArmed(
+    SST_TimeEvt * const me);
+
 void SST_TimeEvt_tick(void); /* static handle all instantiated time events */
 
 /* SST Kernel facilities ---------------------------------------------------*/

--- a/include/sst.hpp
+++ b/include/sst.hpp
@@ -104,6 +104,7 @@ public:
     TimeEvt(Signal sig, Task *task);
     void arm(TCtr ctr, TCtr interval);
     bool disarm(void);
+    [[nodiscard]] bool isArmed() const;
 
     static void tick(void);
 };

--- a/sst0_c/examples/blinky/blinky.c
+++ b/sst0_c/examples/blinky/blinky.c
@@ -82,6 +82,7 @@ static void Blinky_dispatch(Blinky * const me, SST_Evt const * const e) {
         case TIMEOUT2_SIG: {
             BSP_ledOff();
             SST_TimeEvt_arm(&me->te1, BSP_TICKS_PER_SEC * 3U/4U, 0U);
+            DBC_ASSERT(__LINE__, SST_TimeEvt_isArmed(&me->te1));
             break;
         }
         default: {
@@ -99,6 +100,7 @@ static void Blinky_init(Blinky * const me, SST_Evt const * const ie) {
     (void)ie; /* unused parameter */
     SST_TimeEvt_arm(&me->te1, 1U,                          BSP_TICKS_PER_SEC);
     SST_TimeEvt_arm(&me->te2, 1U + (BSP_TICKS_PER_SEC/4U), BSP_TICKS_PER_SEC);
+    DBC_ASSERT(__LINE__, SST_TimeEvt_isArmed(&me->te1));
 }
 /*..........................................................................*/
 static void Blinky_dispatch(Blinky * const me, SST_Evt const * const e) {

--- a/sst0_c/src/sst0.c
+++ b/sst0_c/src/sst0.c
@@ -193,6 +193,16 @@ bool SST_TimeEvt_disarm(SST_TimeEvt * const me) {
     return status;
 }
 /*..........................................................................*/
+bool SST_TimeEvt_isArmed(
+    SST_TimeEvt * const me)
+{
+    SST_PORT_CRIT_STAT
+    SST_PORT_CRIT_ENTRY();
+    bool disarmed = (me->ctr == 0U) && (me->interval == 0U);
+    SST_PORT_CRIT_EXIT();
+    return !disarmed;
+}
+/*..........................................................................*/
 void SST_TimeEvt_tick(void) {
     for (SST_TimeEvt *t = timeEvt_head;
          t != (SST_TimeEvt *)0;

--- a/sst0_cpp/examples/blinky/blinky.cpp
+++ b/sst0_cpp/examples/blinky/blinky.cpp
@@ -68,6 +68,7 @@ void Blinky::dispatch(SST::Evt const * const e) {
         case TIMEOUT1_SIG: {
             BSP::ledOff();
             m_te2.arm(BSP::TICKS_PER_SEC*3U/4U, 0U);
+            DBC_ASSERT(__LINE__, m_te2.isArmed());
             break;
         }
         case TIMEOUT2_SIG: {

--- a/sst0_cpp/src/sst0.cpp
+++ b/sst0_cpp/src/sst0.cpp
@@ -183,6 +183,14 @@ bool TimeEvt::disarm(void) {
     return status;
 }
 //............................................................................
+bool TimeEvt::isArmed() const {
+    SST_PORT_CRIT_STAT
+    SST_PORT_CRIT_ENTRY();
+    bool disarmed = (m_ctr == 0U) && (m_interval == 0U);
+    SST_PORT_CRIT_EXIT();
+    return !disarmed;
+}
+//............................................................................
 void TimeEvt::tick(void) {
     for (TimeEvt *t = timeEvt_head; t != nullptr; t = t->m_next) {
         SST_PORT_CRIT_STAT

--- a/sst_c/examples/blinky/blinky.c
+++ b/sst_c/examples/blinky/blinky.c
@@ -82,6 +82,7 @@ static void Blinky_dispatch(Blinky * const me, SST_Evt const * const e) {
         case TIMEOUT2_SIG: {
             BSP_ledOff();
             SST_TimeEvt_arm(&me->te1, BSP_TICKS_PER_SEC * 3U/4U, 0U);
+            DBC_ASSERT(__LINE__, SST_TimeEvt_isArmed(&me->te1));
             break;
         }
         default: {
@@ -99,6 +100,7 @@ static void Blinky_init(Blinky * const me, SST_Evt const * const ie) {
     (void)ie; /* unused parameter */
     SST_TimeEvt_arm(&me->te1, 1U,                          BSP_TICKS_PER_SEC);
     SST_TimeEvt_arm(&me->te2, 1U + (BSP_TICKS_PER_SEC/4U), BSP_TICKS_PER_SEC);
+    DBC_ASSERT(__LINE__, SST_TimeEvt_isArmed(&me->te1));
 }
 /*..........................................................................*/
 static void Blinky_dispatch(Blinky * const me, SST_Evt const * const e) {

--- a/sst_c/src/sst.c
+++ b/sst_c/src/sst.c
@@ -134,6 +134,16 @@ bool SST_TimeEvt_disarm(SST_TimeEvt * const me) {
     return status;
 }
 /*..........................................................................*/
+bool SST_TimeEvt_isArmed(
+    SST_TimeEvt * const me)
+{
+    SST_PORT_CRIT_STAT
+    SST_PORT_CRIT_ENTRY();
+    bool disarmed = (me->ctr == 0U) && (me->interval == 0U);
+    SST_PORT_CRIT_EXIT();
+    return !disarmed;
+}
+/*..........................................................................*/
 void SST_TimeEvt_tick(void) {
     for (SST_TimeEvt *t = timeEvt_head;
          t != (SST_TimeEvt *)0;

--- a/sst_cpp/examples/blinky/blinky.cpp
+++ b/sst_cpp/examples/blinky/blinky.cpp
@@ -68,6 +68,7 @@ void Blinky::dispatch(SST::Evt const * const e) {
         case TIMEOUT1_SIG: {
             BSP::ledOff();
             m_te2.arm(BSP::TICKS_PER_SEC*3U/4U, 0U);
+            DBC_ASSERT(__LINE__, m_te2.isArmed());
             break;
         }
         case TIMEOUT2_SIG: {

--- a/sst_cpp/src/sst.cpp
+++ b/sst_cpp/src/sst.cpp
@@ -123,6 +123,14 @@ bool TimeEvt::disarm(void) {
     return status;
 }
 //............................................................................
+bool TimeEvt::isArmed() const {
+    SST_PORT_CRIT_STAT
+    SST_PORT_CRIT_ENTRY();
+    bool disarmed = (m_ctr == 0U) && (m_interval == 0U);
+    SST_PORT_CRIT_EXIT();
+    return !disarmed;
+}
+//............................................................................
 void TimeEvt::tick(void) {
     for (TimeEvt *t = timeEvt_head; t != nullptr; t = t->m_next) {
         SST_PORT_CRIT_STAT


### PR DESCRIPTION
In my client's firmware project using SST0 C++, I needed an "is armed" method for the timers. This pull request attempts to contribute this change to each version of SST. I confirmed each build against the GNU makefiles only, in a Debian 12 environment.